### PR TITLE
Fix make issue

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ exercises.tex figures.tex: ex-fig-ref.pl
 	./ex-fig-ref.pl -f > figures.tex
 
 %.pdf: %.svg
-	inkscape -f $(abspath $<) -C -A $(abspath $@)
+	inkscape $(abspath $<) --export-area-page --export-filename $(abspath $@)
 
 clean:
 	latexmk -CA

--- a/src/jsicp.tex
+++ b/src/jsicp.tex
@@ -167,7 +167,7 @@
 \newcommand{\uppersc}[1]{{\fontspec[Letters=UppercaseSmallCaps]{Linux Libertine O}#1}}
 \newcommand{\newterm}[1]{\index{#1}\emph{#1}}
 \newcommand{\jnewterm}[1]{\index{#1}{\bf #1}}
-\newcommand{\strong}[1]{\textbf{#1}}
+%% \newcommand{\strong}[1]{\textbf{#1}}
 \newcommand{\var}[1]{\textsl{#1}}
 \newcommand{\code}[1]{\texttt{#1}}
 \newcommand{\link}[1]{\hyperref[#1]{#1}}


### PR DESCRIPTION
make時のエラーを解消しました。そちらの環境でもお確かめ頂ければと
思います。

## 環境
```
$ inkscape --version
Inkscape 1.1 (c4e8f9ed74, 2021-05-24)

$ xelatex --version
XeTeX 3.141592653-2.6-0.999993 (TeX Live 2021/Arch Linux)
kpathsea version 6.3.3
Copyright 2021 SIL International, Jonathan Kew and Khaled Hosny.
There is NO warranty.  Redistribution of this software is
covered by the terms of both the XeTeX copyright and
the Lesser GNU General Public License.
For more information about these matters, see the file
named COPYING and the XeTeX source.
Primary author of XeTeX: Jonathan Kew.
Compiled with ICU version 69.1; using 69.1
Compiled with zlib version 1.2.11; using 1.2.11
Compiled with FreeType2 version 2.10.4; using 2.10.4
Compiled with Graphite2 version 1.3.14; using 1.3.14
Compiled with HarfBuzz version 2.8.0; using 2.8.1
Compiled with libpng version 1.6.37; using 1.6.37
Compiled with pplib version v2.05 less toxic i hope
Compiled with fontconfig version 2.13.93; using 2.13.93

$ pdflatex --version
pdfTeX 3.141592653-2.6-1.40.22 (TeX Live 2021/Arch Linux)
kpathsea version 6.3.3
Copyright 2021 Han The Thanh (pdfTeX) et al.
There is NO warranty.  Redistribution of this software is
covered by the terms of both the pdfTeX copyright and
the Lesser GNU General Public License.
For more information about these matters, see the file
named COPYING and the pdfTeX source.
Primary author of pdfTeX: Han The Thanh (pdfTeX) et al.
Compiled with libpng 1.6.37; using libpng 1.6.37
Compiled with zlib 1.2.11; using zlib 1.2.11
Compiled with xpdf version 4.03
```

---

またこちらの環境では以下のフォントのインストールが必要だったこと
をメモとして残しておきます。
````
$ yay -S adobe-source-han-serif-jp-fonts \
         adobe-source-han-sans-jp-fonts \
         ttf-cmu-serif ttf-linux-libertine \
         ttf-linux-libertine
````